### PR TITLE
ConfigProxy:

### DIFF
--- a/ansible-modules/netscaler.py
+++ b/ansible-modules/netscaler.py
@@ -58,9 +58,15 @@ class ConfigProxy(object):
             if attribute in transforms:
                 for transform in self.transforms[attribute]:
                     if transform == 'bool_yes_no':
-                        value = 'YES' if value is True else 'NO'
+                        if value is True:
+                            value = 'YES'
+                        elif value is False:
+                            value = 'NO'
                     elif transform == 'bool_on_off':
-                        value = 'ON' if value is True else 'OFF'
+                        if value is True:
+                            value = 'ON'
+                        elif value is False:
+                            value = 'OFF'
                     elif callable(transform):
                         value = transform(value)
                     else:


### PR DESCRIPTION
Replaced PEP 308 Conditional Expression with if statement in
  ConfigProxy 'transforms' initialization.
  The Conditional Expression was causing non-present attributes to be
  initialized with the value of the 'else' part.
  Attributes in the 'transforms' dict must only be passed to the NITRO
  API, if the attribute was actually part of the playbook task.