### PR TITLE
Add graceful disable netscaler_server option

### DIFF
--- a/test/integration/roles/netscaler_server/tests/nitro/server.yaml
+++ b/test/integration/roles/netscaler_server/tests/nitro/server.yaml
@@ -39,6 +39,9 @@
   vars:
     check_mode: no
 
+- assert:
+    that: result|changed
+
 - include: "{{ role_path }}/tests/nitro/server/update.yaml"
   vars:
     check_mode: yes
@@ -47,6 +50,20 @@
     that: not result|changed
 
 - include: "{{ role_path }}/tests/nitro/server/update.yaml"
+  vars:
+    check_mode: no
+
+- assert:
+    that: not result|changed
+
+- include: "{{ role_path }}/tests/nitro/server/disable.yaml"
+  vars:
+    check_mode: yes
+
+- assert:
+    that: not result|changed
+
+- include: "{{ role_path }}/tests/nitro/server/disable.yaml"
   vars:
     check_mode: no
 

--- a/test/integration/roles/netscaler_server/tests/nitro/server/disable.yaml
+++ b/test/integration/roles/netscaler_server/tests/nitro/server/disable.yaml
@@ -1,0 +1,16 @@
+
+- name: Graceful disable basic server
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"
+  netscaler_server:
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+
+    state: present
+
+    name: test-server-1
+    ipaddress: 11.11.11.11
+    disabled: yes
+    graceful: yes


### PR DESCRIPTION
Added the "graceful" option.
This has the effect of the server waiting on connections to terminate before disabling.
Fixes #14 