### PR TITLE
Modules perf optimization

### DIFF
--- a/ansible-modules/netscaler_cs_policy.py
+++ b/ansible-modules/netscaler_cs_policy.py
@@ -158,6 +158,10 @@ def main():
         rule=dict(type='str'),
         domain=dict(type='str'),
         action=dict(type='str'),
+        mas_proxy_call=dict(
+            default=False,
+            type='bool'
+        ),
     )
 
     hand_inserted_arguments = dict(

--- a/ansible-modules/netscaler_cs_policy.py
+++ b/ansible-modules/netscaler_cs_policy.py
@@ -5,13 +5,12 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-__metaclass__ = type
 
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -123,18 +122,21 @@ except ImportError as e:
 
 def policy_exists(client, module):
     log('Checking if policy exists')
-    if cspolicy.count_filtered(client, 'policyname:%s' % module.params['policyname']) > 0:
+    try:
+        cspolicy.get(client, module.params['policyname'])
         return True
-    else:
+    except:
         return False
 
 
 def policy_identical(client, module, cspolicy_proxy):
     log('Checking if defined policy is identical to configured')
-    if cspolicy.count_filtered(client, 'policyname:%s' % module.params['policyname']) == 0:
+    try:
+        policy_list = cspolicy.get(client, module.params['policyname'])
+    except:
         return False
-    policy_list = cspolicy.get_filtered(client, 'policyname:%s' % module.params['policyname'])
-    diff_dict = cspolicy_proxy.diff_object(policy_list[0])
+
+    diff_dict = cspolicy_proxy.diff_object(policy_list)
     if 'ip' in diff_dict:
         del diff_dict['ip']
     if len(diff_dict) == 0:
@@ -144,8 +146,8 @@ def policy_identical(client, module, cspolicy_proxy):
 
 
 def diff_list(client, module, cspolicy_proxy):
-    policy_list = cspolicy.get_filtered(client, 'policyname:%s' % module.params['policyname'])
-    return cspolicy_proxy.diff_object(policy_list[0])
+    policy_list = cspolicy.get(client, module.params['policyname'])
+    return cspolicy_proxy.diff_object(policy_list)
 
 
 def main():
@@ -256,7 +258,8 @@ def main():
                 if not policy_exists(client, module):
                     module.fail_json(msg='Policy does not exist', **module_result)
                 if not policy_identical(client, module, cspolicy_proxy):
-                    module.fail_json(msg='Policy differs from configured', diff=diff_list(client, module, cspolicy_proxy), **module_result)
+                    module.fail_json(msg='Policy differs from configured',
+                                     diff=diff_list(client, module, cspolicy_proxy), **module_result)
 
         elif module.params['state'] == 'absent':
             log('Applying actions for state absent')

--- a/ansible-modules/netscaler_lb_monitor.py
+++ b/ansible-modules/netscaler_lb_monitor.py
@@ -883,7 +883,10 @@ def main():
     module_specific_arguments = dict(
 
         monitorname=dict(type='str'),
-
+        mas_proxy_call=dict(
+            default=False,
+            type='bool'
+        ),
         type=dict(
             type='str',
             choices=[

--- a/ansible-modules/netscaler_lb_monitor.py
+++ b/ansible-modules/netscaler_lb_monitor.py
@@ -1368,7 +1368,6 @@ def main():
                 if lbmonitor_exists:
                     module.fail_json(msg='lb monitor still exists', **module_result)
 
-        module_result['actual_attributes'] = lbmonitor_proxy.get_actual_rw_attributes(filter='monitorname')
     except nitro_exception as e:
         msg = "nitro exception errorcode=%s, message=%s" % (str(e.errorcode), e.message)
         module.fail_json(msg=msg, **module_result)

--- a/ansible-modules/netscaler_lb_vserver.py
+++ b/ansible-modules/netscaler_lb_vserver.py
@@ -971,7 +971,6 @@ diff:
     type: dict
     sample: { 'clttimeout': 'difference. ours: (float) 10.0 other: (float) 20.0' }
 '''
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netscaler.netscaler import (
     ConfigProxy,
@@ -999,24 +998,29 @@ except ImportError as e:
 
 def lb_vserver_exists(client, module):
     log('Checking if lb vserver exists')
-    if lbvserver.count_filtered(client, 'name:%s' % module.params['name']) > 0:
+    try:
+        lbvserver.get(client, module.params['name'])
         return True
-    else:
+    except nitro_exception:
         return False
 
 
 def lb_vserver_identical(client, module, lbvserver_proxy):
     log('Checking if configured lb vserver is identical')
-    lbvserver_list = lbvserver.get_filtered(client, 'name:%s' % module.params['name'])
-    if lbvserver_proxy.has_equal_attributes(lbvserver_list[0]):
+    try:
+        lbvserver_inst = lbvserver.get(client, module.params['name'])
+    except nitro_exception:
+        return False
+
+    if lbvserver_proxy.has_equal_attributes(lbvserver_inst):
         return True
     else:
         return False
 
 
 def lb_vserver_diff(client, module, lbvserver_proxy):
-    lbvserver_list = lbvserver.get_filtered(client, 'name:%s' % module.params['name'])
-    return lbvserver_proxy.diff_object(lbvserver_list[0])
+    lbvserver_inst = lbvserver.get(client, module.params['name'])
+    return lbvserver_proxy.diff_object(lbvserver_inst)
 
 
 def get_configured_service_bindings(client, module):

--- a/ansible-modules/netscaler_lb_vserver.py
+++ b/ansible-modules/netscaler_lb_vserver.py
@@ -1297,6 +1297,10 @@ def main():
 
     module_specific_arguments = dict(
         name=dict(type='str'),
+        mas_proxy_call=dict(
+            default=False,
+            type='bool'
+        ),
         servicetype=dict(
             type='str',
             choices=[

--- a/ansible-modules/netscaler_nitro_request.py
+++ b/ansible-modules/netscaler_nitro_request.py
@@ -365,6 +365,7 @@ class NitroAPICaller(object):
         instance_ip=dict(type='str'),
         instance_name=dict(type='str'),
         instance_id=dict(type='str'),
+        timeout=dict(type='int', default=45),
     )
 
     def __init__(self):
@@ -525,13 +526,14 @@ class NitroAPICaller(object):
         )
 
         data = self._module.jsonify({self._module.params['resource']: self._module.params['attributes']})
-
+        timeout = self._module.params['timeout']
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             data=data,
             method='POST',
+            timeout=timeout,
         )
 
         result = {}
@@ -563,13 +565,14 @@ class NitroAPICaller(object):
         )
 
         data = self._module.jsonify({self._module.params['resource']: self._module.params['attributes']})
-
+        timeout = self._module.params['timeout']
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             data=data,
             method='PUT',
+            timeout=timeout,
         )
 
         result = {}
@@ -595,11 +598,13 @@ class NitroAPICaller(object):
             self._module.params['name'],
         )
 
+        timeout = self._module.params['timeout']
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             method='GET',
+            timeout=timeout,
         )
 
         result = {}
@@ -630,11 +635,13 @@ class NitroAPICaller(object):
 
         url = '?'.join([url, args])
 
+        timeout = self._module.params['timeout']
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             method='GET',
+            timeout=timeout,
         )
         result = {}
         self.edit_response_data(r, info, result, success_status=200)
@@ -663,11 +670,13 @@ class NitroAPICaller(object):
             filter_str,
         )
 
+        timeout = self._module.params['timeout']
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             method='GET',
+            timeout=timeout,
         )
 
         result = {}
@@ -688,11 +697,13 @@ class NitroAPICaller(object):
         )
 
         print('headers %s' % self._headers)
+        timeout = self._module.params['timeout']
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             method='GET',
+            timeout=timeout,
         )
 
         result = {}
@@ -717,12 +728,14 @@ class NitroAPICaller(object):
             self._module.params['resource'],
             self._module.params['name'],
         )
+        timeout = self._module.params['timeout']
 
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             method='DELETE',
+            timeout=timeout,
         )
 
         result = {}
@@ -754,11 +767,14 @@ class NitroAPICaller(object):
         args = 'args=' + args
 
         url = '?'.join([url, args])
+
+        timeout = self._module.params['timeout']
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             method='DELETE',
+            timeout=timeout,
         )
         result = {}
         self.edit_response_data(r, info, result, success_status=200)
@@ -780,11 +796,13 @@ class NitroAPICaller(object):
             self._module.params['resource'],
         )
 
+        timeout = self._module.params['timeout']
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             method='GET',
+            timeout=timeout,
         )
 
         result = {}
@@ -821,12 +839,14 @@ class NitroAPICaller(object):
 
         data = self._module.jsonify({self._module.params['resource']: self._module.params['attributes']})
 
+        timeout = self._module.params['timeout']
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             data=data,
             method='POST',
+            timeout=timeout,
         )
 
         result = {}
@@ -856,12 +876,14 @@ class NitroAPICaller(object):
 
         data = 'object=\n%s' % self._module.jsonify(login_credentials)
 
+        timeout = self._module.params['timeout']
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             data=data,
             method='POST',
+            timeout=timeout,
         )
         print(r, info)
 
@@ -888,12 +910,15 @@ class NitroAPICaller(object):
                 'nsconfig': {},
             }
         )
+
+        timeout = self._module.params['timeout']
         r, info = fetch_url(
             self._module,
             url=url,
             headers=self._headers,
             data=data,
             method='POST',
+            timeout=timeout,
         )
 
         result = {}
@@ -905,7 +930,6 @@ class NitroAPICaller(object):
 
 
 def main():
-
     nitro_api_caller = NitroAPICaller()
     nitro_api_caller.main()
 

--- a/ansible-modules/netscaler_server.py
+++ b/ansible-modules/netscaler_server.py
@@ -154,6 +154,7 @@ diff:
 try:
     from nssrc.com.citrix.netscaler.nitro.resource.config.basic.server import server
     from nssrc.com.citrix.netscaler.nitro.exception.nitro_exception import nitro_exception
+
     PYTHON_SDK_IMPORTED = True
 except ImportError as e:
     PYTHON_SDK_IMPORTED = False
@@ -165,15 +166,18 @@ from ansible.module_utils.network.netscaler.netscaler import ConfigProxy, get_ni
 
 def server_exists(client, module):
     log('Checking if server exists')
-    if server.count_filtered(client, 'name:%s' % module.params['name']) > 0:
+    try:
+        server.get(client, module.params['name'])
         return True
-    else:
+    except nitro_exception:
         return False
 
 
 def server_identical(client, module, server_proxy):
     log('Checking if configured server is identical')
-    if server.count_filtered(client, 'name:%s' % module.params['name']) == 0:
+    try:
+        server.get(client, module.params['name'])
+    except nitro_exception:
         return False
     diff = diff_list(client, module, server_proxy)
 
@@ -190,7 +194,7 @@ def server_identical(client, module, server_proxy):
 
 
 def diff_list(client, module, server_proxy):
-    ret_val = server_proxy.diff_object(server.get_filtered(client, 'name:%s' % module.params['name'])[0]),
+    ret_val = server_proxy.diff_object(server.get(client, module.params['name'])),
     return ret_val[0]
 
 

--- a/ansible-modules/netscaler_server.py
+++ b/ansible-modules/netscaler_server.py
@@ -212,7 +212,10 @@ def main():
 
     module_specific_arguments = dict(
         name=dict(type='str'),
-        ipaddress=dict(type='str'),
+        mas_proxy_call=dict(
+            default=False,
+            type='bool'
+        ),        ipaddress=dict(type='str'),
         domain=dict(type='str'),
         translationip=dict(type='str'),
         translationmask=dict(type='str'),

--- a/ansible-modules/netscaler_servicegroup.py
+++ b/ansible-modules/netscaler_servicegroup.py
@@ -410,18 +410,23 @@ except ImportError as e:
 
 def servicegroup_exists(client, module):
     log('Checking if service group exists')
-    count = servicegroup.count_filtered(client, 'servicegroupname:%s' % module.params['servicegroupname'])
-    log('count is %s' % count)
-    if count > 0:
+    try:
+        servicegroup.get(client, module.params['servicegroupname'])
+        log('Servicegroup exists')
         return True
-    else:
+    except nitro_exception:
+        log('Servicegroup doesn not exist')
         return False
 
 
 def servicegroup_identical(client, module, servicegroup_proxy):
     log('Checking if service group is identical')
-    servicegroups = servicegroup.get_filtered(client, 'servicegroupname:%s' % module.params['servicegroupname'])
-    if servicegroup_proxy.has_equal_attributes(servicegroups[0]):
+    try:
+        servicegroup_inst = servicegroup.get(client, module.params['servicegroupname'])
+    except nitro_exception:
+        return False
+
+    if servicegroup_proxy.has_equal_attributes(servicegroup_inst):
         return True
     else:
         return False
@@ -675,8 +680,12 @@ def sync_monitor_bindings(client, module):
 
 
 def diff(client, module, servicegroup_proxy):
-    servicegroup_list = servicegroup.get_filtered(client, 'servicegroupname:%s' % module.params['servicegroupname'])
-    diff_object = servicegroup_proxy.diff_object(servicegroup_list[0])
+    try:
+        servicegroup_inst = servicegroup.get(client, module.params['servicegroupname'])
+    except nitro_exception:
+        return False
+
+    diff_object = servicegroup_proxy.diff_object(servicegroup_inst)
     return diff_object
 
 

--- a/ansible-modules/netscaler_servicegroup.py
+++ b/ansible-modules/netscaler_servicegroup.py
@@ -703,6 +703,10 @@ def main():
 
     module_specific_arguments = dict(
         servicegroupname=dict(type='str'),
+        mas_proxy_call=dict(
+            default=False,
+            type='bool'
+        ),
         servicetype=dict(
             type='str',
             choices=[


### PR DESCRIPTION
Hi,
We've faced some performance issues on our NS appliance so had to implement some optimizations.
On heavy loaded Netscaler appliance modules didn't work due to API timeout or unacceptable run time (more than 5 min per module) 
* Mostly it's about replacing "get_filtered" or "count_filtered" call with "get". 
I don't know why "*_filtered" used initially but it seems using "get" instead doesn't break anything but dramatically reduces modules run time. It's being actively tested for more than 3-4 months.
* *netscaler_lb_monitor.py* was even slower than other due to multiple API calls in methods *lbmonitor_identical* and *lbmonitor_exists* so it has been optimized a bit more. 
* added "mas_proxy_call" module args definition. Otherwise modules would fail.
* added "timeout" option to *netscaler_nitro_request.py* to override fetch_url() defaults.  

Results:
```
netscaler_v2 : Create CS policy  ---- 654.87s
netscaler_v2 : Create servers ------- 500.88s
netscaler_v2 : Create lb vserver  --- 396.32s
netscaler_v2 : Create serviceGroup  - 378.33s
netscaler_v2 : Set lb monitor  ------ 254.69s

netscaler_v2 : Create CS policy  ---- 2.52s
netscaler_v2 : Create servers  ------ 2.81s
netscaler_v2 : Create lb vserver ---- 9.92s
netscaler_v2 : Create serviceGroup -- 5.52s
netscaler_v2 : Set lb monitor  ------ 5.32s
```