### PR TITLE
Change missing unit tests module dirs installation message.

### DIFF
--- a/install.py
+++ b/install.py
@@ -139,7 +139,8 @@ def main():
                 dst=os.path.join(netscaler_unit_tests_dir, file)
             )
     else:
-        print('Could not find units tests dir')
+        print('Warning. Could not install unit tests. You will not be able to run the unit tests for the modules.')
+        print('This does not affect normal module functionality.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make clear the fact that the functionality of the modules is unaffected
by this warning message.

Fixes #73 