### PR TITLE
Encode Monitor Bindings to utf-8 to avoid u'' Comparisons mismatches

### DIFF
--- a/ansible-modules/citrix_adc_servicegroup.py
+++ b/ansible-modules/citrix_adc_servicegroup.py
@@ -558,9 +558,9 @@ def sync_service_members(client, module):
 
 
 def monitor_binding_equal(configured, actual):
-    if any([configured.monitorname != actual.monitor_name,
-            configured.servicegroupname != actual.servicegroupname,
-            configured.weight != float(actual.weight)]):
+    if any([configured.monitorname != actual.monitor_name.encode("utf-8"),
+            configured.servicegroupname != actual.servicegroupname.encode("utf-8"),
+            configured.weight != actual.weight.encode("utf-8")]):
         return False
     return True
 


### PR DESCRIPTION
In our organisation we were experiencing an error where monitor binding comparisons would fail as a result of incorrect encoding between inputs and retrieved values following a successful deployment.

The module would report a failure as the incoming string was not matching the value fetched form the netscaler config. This PR fixes this particular issue for our use-case, though some additional feedback would be appreciated if this doesn't work in your testing envionment.

The specific error was the variable 'actual' contained unicode strings rather than standard python strings